### PR TITLE
Make tslint happy

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-export type LocationUnion = LatitudeLongitude | LatLng | LatLon;
-
 interface LatitudeLongitude {
     latitude: number;
     longitude: number;
@@ -17,7 +15,27 @@ interface LatLon {
 
 /**
  * Return the Haversine distance in meters
- * @param a first location
- * @param b second location
+ * @param a - first location
+ * @param b - second location
  */
-export default function haversineDistance(a: LocationUnion, b: LocationUnion): number;
+declare function haversineDistance(a: LatitudeLongitude, b: LatitudeLongitude): number;
+
+/**
+ * Return the Haversine distance in meters
+ * @param a - first location
+ * @param b - second location
+ */
+declare function haversineDistance(a: LatLng, b: LatLng): number;
+
+/**
+ * Return the Haversine distance in meters
+ * @param a - first location
+ * @param b - second location
+ */
+declare function haversineDistance(a: LatLon, b: LatLon): number;
+
+declare namespace haversineDistance {
+    export function haversineDistance(): number;
+}
+
+export = haversineDistance;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haversine-distance",
-  "version": "1.1.6",
+  "version": "1.2.0",
   "description": "Haversine formula in Javascript. In meters. Nothing more.",
   "main": "index.js",
   "types": "types.d.ts",


### PR DESCRIPTION
When used in a .ts file, if I use it like:

```
import * as haversineDistance from 'haversine-distance';
// import haversineDistance = require('haversine-distance'); will upset the tslint similarly.

const a = { lat: 32.2084468, lng: 130.4001656 };
const b = { lat: 32.2084468, lng: 130.4001656 };

console.log(haversineDistance(a, b));
```

It will upset the tslint. `haversineDistance(a, b)` is red-underlined, and when I hover it, there's this message:

> This expression is not callable.... [package] has no call signatures.

-----

So, with this PR, tslint will no longer complain when used in a ts files. 👍 