### PR TITLE
Add support and tests for 0 degrees latitude and longitude

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,10 +15,10 @@ function hav (x) {
 
 // hav(theta) = hav(bLat - aLat) + cos(aLat) * cos(bLat) * hav(bLon - aLon)
 function haversineDistance (a, b) {
-  const aLat = toRad(Array.isArray(a) ? a[1] : a.latitude || a.lat)
-  const bLat = toRad(Array.isArray(b) ? b[1] : b.latitude || b.lat)
-  const aLng = toRad(Array.isArray(a) ? a[0] : a.longitude || a.lng || a.lon)
-  const bLng = toRad(Array.isArray(b) ? b[0] : b.longitude || b.lng || b.lon)
+  const aLat = toRad(Array.isArray(a) ? a[1] : a.latitude ?? a.lat)
+  const bLat = toRad(Array.isArray(b) ? b[1] : b.latitude ?? b.lat)
+  const aLng = toRad(Array.isArray(a) ? a[0] : a.longitude ?? a.lng ?? a.lon)
+  const bLng = toRad(Array.isArray(b) ? b[0] : b.longitude ?? b.lng ?? b.lon)
 
   const ht = hav(bLat - aLat) + cos(aLat) * cos(bLat) * hav(bLng - aLng)
   return 2 * R * asin(sqrt(ht))

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -1,4 +1,18 @@
 [
+	{
+		"description": "London (0° longitude) to Kisumu (0° latitude)",
+		"arguments": [
+			{
+				"latitude": 51.5072,
+				"longitude": 0
+			},
+			{
+				"latitude": 0,
+				"longitude": 34.7680
+			}
+		],
+		"expected": 6595666
+	},
   {
     "arguments": [
       {


### PR DESCRIPTION
fixes #13

The use of `||` was causing latitudes or longitudes of `0` to get passed by, as `0` is "falsy".

By switching to the [nullish coalescing operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing) (`??`), only null or undefined values get passed by, allowing someone to input a true `0` latitude or longitude.

I added a test case to cover this situation (London to Kisumu).